### PR TITLE
Fixing admin routing

### DIFF
--- a/KOService.Application/Commands/Employee/UpdateEmployeeCommand.cs
+++ b/KOService.Application/Commands/Employee/UpdateEmployeeCommand.cs
@@ -11,6 +11,9 @@ namespace KOService.Application.Commands.Employee
         public string Id { get; set; }
         public string FirstName { get; set; }
         public string LastName { get; set; }
+        public string UserName { get; set; }
+        public string Password { get; set; }
+        public string ConfirmPassword { get; set; }
         public EmployeeRole EmployeeRole { get; set; }
     }
 }

--- a/KOService.Application/Commands/Employee/UpdateEmployeeCommand.cs
+++ b/KOService.Application/Commands/Employee/UpdateEmployeeCommand.cs
@@ -12,8 +12,6 @@ namespace KOService.Application.Commands.Employee
         public string FirstName { get; set; }
         public string LastName { get; set; }
         public string UserName { get; set; }
-        public string Password { get; set; }
-        public string ConfirmPassword { get; set; }
         public EmployeeRole EmployeeRole { get; set; }
     }
 }

--- a/KOService.Application/DTOs/Employee/EmployeeDtoWithAccountInfoDto.cs
+++ b/KOService.Application/DTOs/Employee/EmployeeDtoWithAccountInfoDto.cs
@@ -1,0 +1,16 @@
+﻿using KOService.Domain.Authentication;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace KOService.Application.DTOs.Employee
+{
+    public class EmployeeWithAccountInfoDto
+    {
+        public Guid Id { get; set; }
+        public string FirstName { get; set; }
+        public string LastName { get; set; }
+        public EmployeeRole Role { get; set; }
+        public string UserName { get; set; }
+    }
+}

--- a/KOService.Application/Handlers/Employee/GetEmployeeByIdHandler.cs
+++ b/KOService.Application/Handlers/Employee/GetEmployeeByIdHandler.cs
@@ -1,0 +1,39 @@
+﻿using AutoMapper;
+using KOService.Application.DTOs.Employee;
+using KOService.Application.Queries.Employee;
+using KOService.Domain.Entities;
+using KOService.Domain.DbContexts;
+using MediatR;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Microsoft.EntityFrameworkCore;
+
+namespace KOService.Application.Handlers.Employee
+{
+    public class GetEmployeeByIdHandler : RequestHandler<GetEmployeeByIdQuery, EmployeeWithAccountInfoDto>
+    {
+        private KOServiceDbContext _dbContext;
+
+        public GetEmployeeByIdHandler(KOServiceDbContext dbContext)
+        {
+            _dbContext = dbContext;
+        }
+        protected override EmployeeWithAccountInfoDto Handle(GetEmployeeByIdQuery request)
+        {
+            Guid guidToCompare = new Guid(request.Id.ToString().ToLower());
+
+            var employee = _dbContext.Employees.Where(e => e.Id == guidToCompare)
+                .Include(e => e.Identity)                
+                .FirstOrDefault();
+
+            if (employee == null)
+            {
+                throw new Exception("Could not find employee");
+            }
+
+            return Mapper.Map<EmployeeWithAccountInfoDto>(employee);
+        }
+    }
+}

--- a/KOService.Application/Handlers/Employee/UpdateEmployeeHandler.cs
+++ b/KOService.Application/Handlers/Employee/UpdateEmployeeHandler.cs
@@ -22,7 +22,7 @@ namespace KOService.Application.Handlers.Employee
                                      .Include(e => e.Identity)
                                      .FirstOrDefault(e => e.Id.ToString() == request.Id);
 
-            employee.Update(request.FirstName, request.LastName, request.EmployeeRole, request.UserName, request.Password, request.ConfirmPassword);
+            employee.Update(request.FirstName, request.LastName, request.EmployeeRole, request.UserName);
 
             _dbContext.SaveChanges();
         }

--- a/KOService.Application/Handlers/Employee/UpdateEmployeeHandler.cs
+++ b/KOService.Application/Handlers/Employee/UpdateEmployeeHandler.cs
@@ -22,7 +22,7 @@ namespace KOService.Application.Handlers.Employee
                                      .Include(e => e.Identity)
                                      .FirstOrDefault(e => e.Id.ToString() == request.Id);
 
-            employee.Update(request.FirstName, request.LastName, request.EmployeeRole);
+            employee.Update(request.FirstName, request.LastName, request.EmployeeRole, request.UserName, request.Password, request.ConfirmPassword);
 
             _dbContext.SaveChanges();
         }

--- a/KOService.Application/Queries/Employee/GetEmployeeByIdQuery.cs
+++ b/KOService.Application/Queries/Employee/GetEmployeeByIdQuery.cs
@@ -6,7 +6,7 @@ using System.Text;
 
 namespace KOService.Application.Queries.Employee
 {
-    public class GetEmployeeQuery : IRequest<EmployeeDto>
+    public class GetEmployeeByIdQuery : IRequest<EmployeeWithAccountInfoDto>
     {
         public string Id { get; set; }
     }

--- a/KOService.Domain/Entities/Employee.cs
+++ b/KOService.Domain/Entities/Employee.cs
@@ -54,12 +54,17 @@ namespace KOService.Domain.Entities
             TerminationDateTime = DateTime.UtcNow;
         }
 
-        public void Update(string firstName, string lastName, EmployeeRole role)
+        public void Update(string firstName, string lastName, EmployeeRole role, string userName, string password, string confirmPassword)
         {
             SetFirstName(firstName);
             SetLastName(lastName);
+            SetUserName(userName);
 
-            
+            if (password.Count() > 0 && password.Equals(confirmPassword))
+            {
+                Identity.PasswordHash = password;
+            }
+
             Identity.EmployeeRole = role;
         }
 
@@ -81,6 +86,17 @@ namespace KOService.Domain.Entities
             }
 
             FirstName = firstName;
+        }
+
+        private void SetUserName(string userName)
+        {
+            if (string.IsNullOrEmpty(userName))
+            {
+                throw new DomainException("User name has not been provided");
+            }
+
+            Identity.UserName = userName;
+            Identity.NormalizedUserName = userName.ToUpper();
         }
 
     }

--- a/KOService.Domain/Entities/Employee.cs
+++ b/KOService.Domain/Entities/Employee.cs
@@ -54,16 +54,11 @@ namespace KOService.Domain.Entities
             TerminationDateTime = DateTime.UtcNow;
         }
 
-        public void Update(string firstName, string lastName, EmployeeRole role, string userName, string password, string confirmPassword)
+        public void Update(string firstName, string lastName, EmployeeRole role, string userName)
         {
             SetFirstName(firstName);
             SetLastName(lastName);
             SetUserName(userName);
-
-            if (password.Count() > 0 && password.Equals(confirmPassword))
-            {
-                Identity.PasswordHash = password;
-            }
 
             Identity.EmployeeRole = role;
         }

--- a/KOService.Presentation/KOService/src/app/admin/add-employee-form/add-employee-form.component.html
+++ b/KOService.Presentation/KOService/src/app/admin/add-employee-form/add-employee-form.component.html
@@ -29,9 +29,9 @@
             </mat-form-field>
             <mat-form-field>
                 <mat-label for="role">Rola:</mat-label>
-                <select matNativeControl [(ngModel)]="register.employeeRole" id="role" name="role" class="form-control"
+                <select matNativeControl [(ngModel)]="this.chosenPolishRole" id="role" name="role" class="form-control"
                     required>
-                    <option *ngFor="let key of keys">{{roles[key]}}</option>
+                    <option *ngFor="let key of keys">{{rolesPolish[key]}}</option>
                 </select>
             </mat-form-field>
 

--- a/KOService.Presentation/KOService/src/app/admin/add-employee-form/add-employee-form.component.html
+++ b/KOService.Presentation/KOService/src/app/admin/add-employee-form/add-employee-form.component.html
@@ -13,7 +13,7 @@
                     class="form-control" required>
             </mat-form-field>
             <mat-form-field>
-                <mat-label for="userName">Nickname:</mat-label>
+                <mat-label for="userName">Nazwa użytkownika:</mat-label>
                 <input #lastName matInput type="text" [(ngModel)]="register.userName" id="userName" name="userName"
                     class="form-control" required>
             </mat-form-field>

--- a/KOService.Presentation/KOService/src/app/admin/add-employee-form/add-employee-form.component.ts
+++ b/KOService.Presentation/KOService/src/app/admin/add-employee-form/add-employee-form.component.ts
@@ -1,6 +1,7 @@
 import { Component, ViewChild, ElementRef, NgZone, OnInit, OnDestroy } from '@angular/core';
 import { Subscription } from 'rxjs';
 import { Role } from '../../shared/enums/Role';
+import { Router } from '@angular/router';
 import { EmployeeService } from 'src/app/shared/services/employee.service';
 import { RegisterEmployee } from 'src/app/shared/models/register.model';
 
@@ -42,7 +43,7 @@ export class AddEmployeeFormComponent implements OnInit, OnDestroy {
         employeeRole: Role.mechanic
     };
 
-    constructor(private service: EmployeeService, private zone: NgZone) {
+    constructor(private service: EmployeeService, private zone: NgZone, private router: Router) {
         this.keys = Object.keys(Role).filter(k => !isNaN(Number(k)));
     }
 
@@ -51,7 +52,11 @@ export class AddEmployeeFormComponent implements OnInit, OnDestroy {
     }
 
     ngOnDestroy() {
-        this.registerSubscription.unsubscribe();
+        
+    }
+
+    delay(ms: number) {
+        return new Promise( resolve => setTimeout(resolve, ms) );
     }
 
     onSubmit() {
@@ -64,6 +69,8 @@ export class AddEmployeeFormComponent implements OnInit, OnDestroy {
             employeeRole: this.mapPolishRoleToEnglish(this.chosenPolishRole),
         }
 
-        this.registerSubscription = this.service.addEmployee(model).subscribe();
+        this.service.addEmployee(model).subscribe(res => {            
+            console.log("robie subscriba elo");
+        });
     }
 }

--- a/KOService.Presentation/KOService/src/app/admin/add-employee-form/add-employee-form.component.ts
+++ b/KOService.Presentation/KOService/src/app/admin/add-employee-form/add-employee-form.component.ts
@@ -24,7 +24,14 @@ export class AddEmployeeFormComponent implements OnInit {
     ];
     chosenPolishRole : string;
     keys: any[];
-    register: RegisterEmployee;
+    register: RegisterEmployee = {
+        firstName: '',
+        lastName: '',
+        userName: '',
+        employeeRole: Role.mechanic,
+        password: '',
+        confirmPassword: ''
+    }
 
     @ViewChild('firstName') firstName: ElementRef;
     @ViewChild('lastName') lastName: ElementRef;
@@ -46,31 +53,7 @@ export class AddEmployeeFormComponent implements OnInit {
     }
 
     ngOnInit() {
-        if (this.editEmployeeService.employee) {            
-            this.editMode = true;
-            this.service.getEmployee(this.editEmployeeService.employee.id).subscribe(res => {
-                this.register = {
-                    firstName: res.firstName,
-                    lastName: res.lastName,
-                    userName: res.userName,
-                    password: '',
-                    confirmPassword: '',
-                    employeeRole: res.role,
-                }
-                this.chosenPolishRole = this.rolesPolish[this.register.employeeRole];
-            });            
-        }
-        else {
-            this.editMode = false;
-            this.register = {
-                firstName: '',
-                lastName: '',
-                userName: '',
-                password: '',
-                confirmPassword: '',
-                employeeRole: Role.mechanic
-            };
-        }
+        this.resolveInputData();
         this.spinnerService.hide();
         this.firstName.nativeElement.focus();
     }
@@ -106,6 +89,35 @@ export class AddEmployeeFormComponent implements OnInit {
                 });
             });
             
+        }
+    }
+
+    resolveInputData() {
+        if (this.editEmployeeService.employee) {            
+            this.editMode = true;
+            this.service.getEmployee(this.editEmployeeService.employee.id).subscribe(res => {
+                this.register = {
+                    firstName: res.firstName,
+                    lastName: res.lastName,
+                    userName: res.userName,
+                    password: '',
+                    confirmPassword: '',
+                    employeeRole: res.role,
+                }
+                this.chosenPolishRole = this.rolesPolish[this.register.employeeRole];
+            });            
+        }
+        else {
+            this.editMode = false;
+            this.register = {
+                firstName: '',
+                lastName: '',
+                userName: '',
+                password: '',
+                confirmPassword: '',
+                employeeRole: Role.mechanic
+            };
+            console.log(this.register);
         }
     }
 }

--- a/KOService.Presentation/KOService/src/app/admin/add-employee-form/add-employee-form.component.ts
+++ b/KOService.Presentation/KOService/src/app/admin/add-employee-form/add-employee-form.component.ts
@@ -46,7 +46,7 @@ export class AddEmployeeFormComponent implements OnInit {
     }
 
     ngOnInit() {
-        if (this.editEmployeeService) {            
+        if (this.editEmployeeService.employee) {            
             this.editMode = true;
             this.service.getEmployee(this.editEmployeeService.employee.id).subscribe(res => {
                 this.register = {

--- a/KOService.Presentation/KOService/src/app/admin/add-employee-form/add-employee-form.component.ts
+++ b/KOService.Presentation/KOService/src/app/admin/add-employee-form/add-employee-form.component.ts
@@ -23,15 +23,7 @@ export class AddEmployeeFormComponent implements OnInit {
         "Administrator"
     ];
     keys: any[];
-
-    register: RegisterEmployee = {
-        firstName: '',
-        lastName: '',
-        userName: '',
-        password: '',
-        confirmPassword: '',
-        employeeRole: Role.mechanic
-    };
+    register: RegisterEmployee;
 
     @ViewChild('firstName') firstName: ElementRef;
     @ViewChild('lastName') lastName: ElementRef;
@@ -53,17 +45,35 @@ export class AddEmployeeFormComponent implements OnInit {
     }
 
     ngOnInit() {
-        this.firstName.nativeElement.focus();
         if (this.editEmployeeService) {
             // this.spinnerService.show();
             console.log(this.editEmployeeService.employee.firstName + " " + this.editEmployeeService.employee.lastName);
-            let response = this.service.getEmployee(this.editEmployeeService.employee.id);
-            console.log(response);
-            console.log(JSON.stringify(response));
-
+            console.log('id: ' + this.editEmployeeService.employee.id);
+            let response = this.service.getEmployee(this.editEmployeeService.employee.id).subscribe(res => {
+                console.log(JSON.stringify(res));
+                this.register = {
+                    firstName: res.firstName,
+                    lastName: res.lastName,
+                    userName: res.userName,
+                    password: '',
+                    confirmPassword: '',
+                    employeeRole: res.role,
+                }
+            });
 
             // this.spinnerService.hide();
         }
+        else {
+            this.register = {
+                firstName: '',
+                lastName: '',
+                userName: '',
+                password: '',
+                confirmPassword: '',
+                employeeRole: Role.mechanic
+            };
+        }
+        this.firstName.nativeElement.focus();
     }
 
     onSubmit() {

--- a/KOService.Presentation/KOService/src/app/admin/add-employee-form/add-employee-form.component.ts
+++ b/KOService.Presentation/KOService/src/app/admin/add-employee-form/add-employee-form.component.ts
@@ -64,8 +64,6 @@ export class AddEmployeeFormComponent implements OnInit, OnDestroy {
             employeeRole: this.mapPolishRoleToEnglish(this.chosenPolishRole),
         }
 
-        console.log("rola: " + model.employeeRole);
-
         this.registerSubscription = this.service.addEmployee(model).subscribe();
     }
 }

--- a/KOService.Presentation/KOService/src/app/admin/add-employee-form/add-employee-form.component.ts
+++ b/KOService.Presentation/KOService/src/app/admin/add-employee-form/add-employee-form.component.ts
@@ -6,6 +6,7 @@ import { EmployeeService } from 'src/app/shared/services/employee.service';
 import { RegisterEmployee } from 'src/app/shared/models/register.model';
 import { SpinnerService } from 'src/app/core/services/spinner.service';
 import { EditEmployeeService } from 'src/app/shared/services/editEmployee.service';
+import { EmployeePassword } from 'src/app/shared/models/employeePassword.model';
 
 @Component({
     selector: 'app-add-employee-form',
@@ -17,12 +18,12 @@ export class AddEmployeeFormComponent implements OnInit {
     registerSubscription: Subscription;
     editMode : boolean;
     roles = Role;
-    chosenPolishRole = "Mechanik";
     rolesPolish = [
         "Mechanik",
         "Manager",
         "Administrator"
     ];
+    chosenPolishRole : string;
     keys: any[];
     register: RegisterEmployee;
 
@@ -60,6 +61,7 @@ export class AddEmployeeFormComponent implements OnInit {
                     confirmPassword: '',
                     employeeRole: res.role,
                 }
+                this.chosenPolishRole = this.rolesPolish[this.register.employeeRole];
             });            
         }
         else {
@@ -96,10 +98,18 @@ export class AddEmployeeFormComponent implements OnInit {
             });
         }
         else {
-            this.service.updateEmployee(this.editEmployeeService.employee.id, model).subscribe(() => { 
-                this.spinnerService.hide();
-                this.router.navigate(['/admin']);
+            var passwordModel = { 
+                currentPassword: '',
+                newPassword: this.register.password
+            };
+
+            this.service.updateEmployee(this.editEmployeeService.employee.id, model).subscribe(() => {
+                this.service.changeEmployeePassword(model.userName, passwordModel).subscribe(() => {
+                    this.spinnerService.hide();
+                    this.router.navigate(['/admin']);
+                });
             });
+            
         }
     }
 }

--- a/KOService.Presentation/KOService/src/app/admin/add-employee-form/add-employee-form.component.ts
+++ b/KOService.Presentation/KOService/src/app/admin/add-employee-form/add-employee-form.component.ts
@@ -102,7 +102,7 @@ export class AddEmployeeFormComponent implements OnInit {
                     userName: res.userName,
                     password: '',
                     confirmPassword: '',
-                    employeeRole: res.role,
+                    employeeRole: this.editEmployeeService.employee.role,
                 }
                 this.chosenPolishRole = this.rolesPolish[this.register.employeeRole];
             });            
@@ -117,7 +117,6 @@ export class AddEmployeeFormComponent implements OnInit {
                 confirmPassword: '',
                 employeeRole: Role.mechanic
             };
-            console.log(this.register);
         }
     }
 }

--- a/KOService.Presentation/KOService/src/app/admin/add-employee-form/add-employee-form.component.ts
+++ b/KOService.Presentation/KOService/src/app/admin/add-employee-form/add-employee-form.component.ts
@@ -9,13 +9,29 @@ import { RegisterEmployee } from 'src/app/shared/models/register.model';
     templateUrl: './add-employee-form.component.html',
     styleUrls: ['./add-employee-form.component.css']
 })
+
 export class AddEmployeeFormComponent implements OnInit, OnDestroy {
     registerSubscription: Subscription;
     roles = Role;
+    chosenPolishRole = "Mechanik";
+    rolesPolish = [
+        "Mechanik",
+        "Manager",
+        "Administrator"
+    ]
     keys: any[];
 
     @ViewChild('firstName') firstName: ElementRef;
     @ViewChild('lastName') lastName: ElementRef;
+
+    mapPolishRoleToEnglish = function (role: string) {
+        switch(role){
+            case "Mechanik": return Role.mechanic;
+            case "Manager": return Role.manager;
+            case "Administrator": return Role.admin;
+            default: return Role.mechanic;
+        }
+    }
 
     register: RegisterEmployee = {
         firstName: '',
@@ -23,7 +39,7 @@ export class AddEmployeeFormComponent implements OnInit, OnDestroy {
         userName: '',
         password: '',
         confirmPassword: '',
-        employeeRole: Role.mechanic,
+        employeeRole: Role.mechanic
     };
 
     constructor(private service: EmployeeService, private zone: NgZone) {
@@ -45,8 +61,10 @@ export class AddEmployeeFormComponent implements OnInit, OnDestroy {
             firstName: this.register.firstName,
             lastName: this.register.lastName,
             userName: this.register.userName,
-            employeeRole: this.register.employeeRole,
+            employeeRole: this.mapPolishRoleToEnglish(this.chosenPolishRole),
         }
+
+        console.log("rola: " + model.employeeRole);
 
         this.registerSubscription = this.service.addEmployee(model).subscribe();
     }

--- a/KOService.Presentation/KOService/src/app/admin/add-employee-form/add-employee-form.component.ts
+++ b/KOService.Presentation/KOService/src/app/admin/add-employee-form/add-employee-form.component.ts
@@ -6,7 +6,6 @@ import { EmployeeService } from 'src/app/shared/services/employee.service';
 import { RegisterEmployee } from 'src/app/shared/models/register.model';
 import { SpinnerService } from 'src/app/core/services/spinner.service';
 import { EditEmployeeService } from 'src/app/shared/services/editEmployee.service';
-import { EmployeePassword } from 'src/app/shared/models/employeePassword.model';
 
 @Component({
     selector: 'app-add-employee-form',
@@ -49,10 +48,7 @@ export class AddEmployeeFormComponent implements OnInit {
     ngOnInit() {
         if (this.editEmployeeService) {            
             this.editMode = true;
-            console.log(this.editEmployeeService.employee.firstName + " " + this.editEmployeeService.employee.lastName);
-            console.log('id: ' + this.editEmployeeService.employee.id);
-            let response = this.service.getEmployee(this.editEmployeeService.employee.id).subscribe(res => {
-                console.log(JSON.stringify(res));
+            this.service.getEmployee(this.editEmployeeService.employee.id).subscribe(res => {
                 this.register = {
                     firstName: res.firstName,
                     lastName: res.lastName,

--- a/KOService.Presentation/KOService/src/app/admin/add-employee-form/add-employee-form.component.ts
+++ b/KOService.Presentation/KOService/src/app/admin/add-employee-form/add-employee-form.component.ts
@@ -4,6 +4,7 @@ import { Role } from '../../shared/enums/Role';
 import { Router } from '@angular/router';
 import { EmployeeService } from 'src/app/shared/services/employee.service';
 import { RegisterEmployee } from 'src/app/shared/models/register.model';
+import { SpinnerService } from 'src/app/core/services/spinner.service';
 
 @Component({
     selector: 'app-add-employee-form',
@@ -44,7 +45,7 @@ export class AddEmployeeFormComponent implements OnInit {
         }
     }
 
-    constructor(private service: EmployeeService, private router: Router) {
+    constructor(private service: EmployeeService, private router: Router, private spinnerService: SpinnerService) {
         this.keys = Object.keys(Role).filter(k => !isNaN(Number(k)));
     }
 
@@ -62,7 +63,9 @@ export class AddEmployeeFormComponent implements OnInit {
             employeeRole: this.mapPolishRoleToEnglish(this.chosenPolishRole),
         };
 
+        this.spinnerService.show();
         this.service.addEmployee(model).subscribe(() => {
+            this.spinnerService.hide();
             this.router.navigate(['/admin']);
         });
     }

--- a/KOService.Presentation/KOService/src/app/admin/add-employee-form/add-employee-form.component.ts
+++ b/KOService.Presentation/KOService/src/app/admin/add-employee-form/add-employee-form.component.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild, ElementRef, NgZone, OnInit, OnDestroy } from '@angular/core';
+import { Component, ViewChild, ElementRef, OnInit } from '@angular/core';
 import { Subscription } from 'rxjs';
 import { Role } from '../../shared/enums/Role';
 import { Router } from '@angular/router';
@@ -11,7 +11,7 @@ import { RegisterEmployee } from 'src/app/shared/models/register.model';
     styleUrls: ['./add-employee-form.component.css']
 })
 
-export class AddEmployeeFormComponent implements OnInit, OnDestroy {
+export class AddEmployeeFormComponent implements OnInit {
     registerSubscription: Subscription;
     roles = Role;
     chosenPolishRole = "Mechanik";
@@ -19,20 +19,8 @@ export class AddEmployeeFormComponent implements OnInit, OnDestroy {
         "Mechanik",
         "Manager",
         "Administrator"
-    ]
+    ];
     keys: any[];
-
-    @ViewChild('firstName') firstName: ElementRef;
-    @ViewChild('lastName') lastName: ElementRef;
-
-    mapPolishRoleToEnglish = function (role: string) {
-        switch(role){
-            case this.rolesPolish[0]: return Role.mechanic;//.mechanic;
-            case this.rolesPolish[1]: return Role.manager;//.manager;
-            case this.rolesPolish[2]: return Role.admin;//.admin;
-            default: return Role.mechanic;
-        }
-    }
 
     register: RegisterEmployee = {
         firstName: '',
@@ -43,20 +31,25 @@ export class AddEmployeeFormComponent implements OnInit, OnDestroy {
         employeeRole: Role.mechanic
     };
 
-    constructor(private service: EmployeeService, private zone: NgZone, private router: Router) {
+
+    @ViewChild('firstName') firstName: ElementRef;
+    @ViewChild('lastName') lastName: ElementRef;
+
+    mapPolishRoleToEnglish = function (role: string) {
+        switch (role) {
+            case this.rolesPolish[0]: return Role.mechanic;
+            case this.rolesPolish[1]: return Role.manager;
+            case this.rolesPolish[2]: return Role.admin;
+            default: return Role.mechanic;
+        }
+    }
+
+    constructor(private service: EmployeeService, private router: Router) {
         this.keys = Object.keys(Role).filter(k => !isNaN(Number(k)));
     }
 
     ngOnInit() {
         this.firstName.nativeElement.focus();
-    }
-
-    ngOnDestroy() {
-        
-    }
-
-    delay(ms: number) {
-        return new Promise( resolve => setTimeout(resolve, ms) );
     }
 
     onSubmit() {
@@ -67,10 +60,10 @@ export class AddEmployeeFormComponent implements OnInit, OnDestroy {
             lastName: this.register.lastName,
             userName: this.register.userName,
             employeeRole: this.mapPolishRoleToEnglish(this.chosenPolishRole),
-        }
+        };
 
-        this.service.addEmployee(model).subscribe(res => {            
-            console.log("robie subscriba elo");
+        this.service.addEmployee(model).subscribe(() => {
+            this.router.navigate(['/admin']);
         });
     }
 }

--- a/KOService.Presentation/KOService/src/app/admin/add-employee-form/add-employee-form.component.ts
+++ b/KOService.Presentation/KOService/src/app/admin/add-employee-form/add-employee-form.component.ts
@@ -26,9 +26,9 @@ export class AddEmployeeFormComponent implements OnInit, OnDestroy {
 
     mapPolishRoleToEnglish = function (role: string) {
         switch(role){
-            case "Mechanik": return Role.mechanic;
-            case "Manager": return Role.manager;
-            case "Administrator": return Role.admin;
+            case this.rolesPolish[0]: return Role.mechanic;//.mechanic;
+            case this.rolesPolish[1]: return Role.manager;//.manager;
+            case this.rolesPolish[2]: return Role.admin;//.admin;
             default: return Role.mechanic;
         }
     }

--- a/KOService.Presentation/KOService/src/app/admin/add-employee-form/add-employee-form.component.ts
+++ b/KOService.Presentation/KOService/src/app/admin/add-employee-form/add-employee-form.component.ts
@@ -57,7 +57,11 @@ export class AddEmployeeFormComponent implements OnInit {
         if (this.editEmployeeService) {
             // this.spinnerService.show();
             console.log(this.editEmployeeService.employee.firstName + " " + this.editEmployeeService.employee.lastName);
-            // this.service.getEmployee(this.editEmployeeService.employee.firstName, this.editEmployeeService.employee.lastName);
+            let response = this.service.getEmployee(this.editEmployeeService.employee.id);
+            console.log(response);
+            console.log(JSON.stringify(response));
+
+
             // this.spinnerService.hide();
         }
     }

--- a/KOService.Presentation/KOService/src/app/admin/add-employee-form/add-employee-form.component.ts
+++ b/KOService.Presentation/KOService/src/app/admin/add-employee-form/add-employee-form.component.ts
@@ -5,6 +5,7 @@ import { Router } from '@angular/router';
 import { EmployeeService } from 'src/app/shared/services/employee.service';
 import { RegisterEmployee } from 'src/app/shared/models/register.model';
 import { SpinnerService } from 'src/app/core/services/spinner.service';
+import { EditEmployeeService } from 'src/app/shared/services/editEmployee.service';
 
 @Component({
     selector: 'app-add-employee-form',
@@ -32,7 +33,6 @@ export class AddEmployeeFormComponent implements OnInit {
         employeeRole: Role.mechanic
     };
 
-
     @ViewChild('firstName') firstName: ElementRef;
     @ViewChild('lastName') lastName: ElementRef;
 
@@ -45,12 +45,21 @@ export class AddEmployeeFormComponent implements OnInit {
         }
     }
 
-    constructor(private service: EmployeeService, private router: Router, private spinnerService: SpinnerService) {
+    constructor(private service: EmployeeService,
+        private router: Router,
+        private spinnerService: SpinnerService,
+        private editEmployeeService: EditEmployeeService) {
         this.keys = Object.keys(Role).filter(k => !isNaN(Number(k)));
     }
 
     ngOnInit() {
         this.firstName.nativeElement.focus();
+        if (this.editEmployeeService) {
+            // this.spinnerService.show();
+            console.log(this.editEmployeeService.employee.firstName + " " + this.editEmployeeService.employee.lastName);
+            // this.service.getEmployee(this.editEmployeeService.employee.firstName, this.editEmployeeService.employee.lastName);
+            // this.spinnerService.hide();
+        }
     }
 
     onSubmit() {

--- a/KOService.Presentation/KOService/src/app/admin/add-employee-form/add-employee-form.component.ts
+++ b/KOService.Presentation/KOService/src/app/admin/add-employee-form/add-employee-form.component.ts
@@ -15,6 +15,7 @@ import { EditEmployeeService } from 'src/app/shared/services/editEmployee.servic
 
 export class AddEmployeeFormComponent implements OnInit {
     registerSubscription: Subscription;
+    editMode : boolean;
     roles = Role;
     chosenPolishRole = "Mechanik";
     rolesPolish = [
@@ -45,8 +46,8 @@ export class AddEmployeeFormComponent implements OnInit {
     }
 
     ngOnInit() {
-        if (this.editEmployeeService) {
-            // this.spinnerService.show();
+        if (this.editEmployeeService) {            
+            this.editMode = true;
             console.log(this.editEmployeeService.employee.firstName + " " + this.editEmployeeService.employee.lastName);
             console.log('id: ' + this.editEmployeeService.employee.id);
             let response = this.service.getEmployee(this.editEmployeeService.employee.id).subscribe(res => {
@@ -59,11 +60,10 @@ export class AddEmployeeFormComponent implements OnInit {
                     confirmPassword: '',
                     employeeRole: res.role,
                 }
-            });
-
-            // this.spinnerService.hide();
+            });            
         }
         else {
+            this.editMode = false;
             this.register = {
                 firstName: '',
                 lastName: '',
@@ -73,6 +73,7 @@ export class AddEmployeeFormComponent implements OnInit {
                 employeeRole: Role.mechanic
             };
         }
+        this.spinnerService.hide();
         this.firstName.nativeElement.focus();
     }
 
@@ -86,10 +87,19 @@ export class AddEmployeeFormComponent implements OnInit {
             employeeRole: this.mapPolishRoleToEnglish(this.chosenPolishRole),
         };
 
+
         this.spinnerService.show();
-        this.service.addEmployee(model).subscribe(() => {
+        if (!this.editMode) { 
+            this.service.addEmployee(model).subscribe(() => {
             this.spinnerService.hide();
             this.router.navigate(['/admin']);
-        });
+            });
+        }
+        else {
+            this.service.updateEmployee(this.editEmployeeService.employee.id, model).subscribe(() => { 
+                this.spinnerService.hide();
+                this.router.navigate(['/admin']);
+            });
+        }
     }
 }

--- a/KOService.Presentation/KOService/src/app/admin/home/home.component.html
+++ b/KOService.Presentation/KOService/src/app/admin/home/home.component.html
@@ -25,7 +25,7 @@
       <ng-container matColumnDef="edit">
         <th mat-header-cell *matHeaderCellDef></th>
         <td mat-cell *matCellDef="let row">
-          <mat-icon>
+          <mat-icon (click)="edit(row)">
             edit
           </mat-icon>
         </td>

--- a/KOService.Presentation/KOService/src/app/admin/home/home.component.ts
+++ b/KOService.Presentation/KOService/src/app/admin/home/home.component.ts
@@ -18,6 +18,8 @@ export class HomeComponent implements OnInit {
   displayedColumns = [
     'firstName', 'lastName', 'role', 'edit', 'terminate'
   ];
+  editIconClicked = false;
+  employeeToEdit : Employee;
 
   @ViewChild(MatSort) sort: MatSort;
   @ViewChild(MatPaginator) paginator: MatPaginator;
@@ -25,12 +27,17 @@ export class HomeComponent implements OnInit {
   constructor(private spinnerService: SpinnerService,
     public dialog: MatDialog,
     private employeeService: EmployeeService,
-    private editEmployeeService: EditEmployeeService,
-    private router: Router) {
+    private router: Router,
+    private editEmployeeService: EditEmployeeService) {
    }
 
   ngOnInit() {
     this.getData();
+  }
+
+  ngOnDestroy() {
+    console.log(this.employeeToEdit);
+    if (this.editIconClicked) this.editEmployeeService.employee = this.employeeToEdit;
   }
 
   private getData() {
@@ -51,7 +58,8 @@ export class HomeComponent implements OnInit {
   }
 
   edit(employee: Employee) {
-    this.editEmployeeService.employee = employee;
+    this.employeeToEdit = employee;
+    this.editIconClicked = true;
     this.router.navigate(['/admin/add-employee']);
   }
 

--- a/KOService.Presentation/KOService/src/app/admin/home/home.component.ts
+++ b/KOService.Presentation/KOService/src/app/admin/home/home.component.ts
@@ -1,4 +1,5 @@
-import { Component, NgZone, OnInit, ViewChild } from '@angular/core';
+import { Component, OnInit, ViewChild } from '@angular/core';
+import { Router } from '@angular/router';
 import { EmployeeService } from 'src/app/shared/services/employee.service';
 import { Employee } from 'src/app/shared/models/employee.model';
 import { MatPaginator, MatTableDataSource, MatSort, MatDialog } from '@angular/material';
@@ -22,7 +23,7 @@ export class HomeComponent implements OnInit {
   constructor(private spinnerService: SpinnerService,
     public dialog: MatDialog,
     private employeeService: EmployeeService,
-    private zone:NgZone) {
+    private router: Router) {
    }
 
   ngOnInit() {
@@ -47,7 +48,9 @@ export class HomeComponent implements OnInit {
     }
   }
 
-
+  edit(employee: Employee) {
+    this.router.navigate(['/admin/add-employee']);
+  }
 
   terminate(employee: Employee) {
     const dialogRef = this.dialog.open(ConfirmationComponent, {

--- a/KOService.Presentation/KOService/src/app/admin/home/home.component.ts
+++ b/KOService.Presentation/KOService/src/app/admin/home/home.component.ts
@@ -5,6 +5,8 @@ import { Employee } from 'src/app/shared/models/employee.model';
 import { MatPaginator, MatTableDataSource, MatSort, MatDialog } from '@angular/material';
 import { ConfirmationComponent } from 'src/app/shared/components/confirmation/confirmation.component';
 import { SpinnerService } from 'src/app/core/services/spinner.service';
+import { EditEmployeeService } from 'src/app/shared/services/editEmployee.service';
+
 @Component({
   selector: 'app-home',
   templateUrl: './home.component.html',
@@ -23,11 +25,11 @@ export class HomeComponent implements OnInit {
   constructor(private spinnerService: SpinnerService,
     public dialog: MatDialog,
     private employeeService: EmployeeService,
+    private editEmployeeService: EditEmployeeService,
     private router: Router) {
    }
 
   ngOnInit() {
-    console.log("home component ngOnInit");
     this.getData();
   }
 
@@ -49,6 +51,7 @@ export class HomeComponent implements OnInit {
   }
 
   edit(employee: Employee) {
+    this.editEmployeeService.employee = employee;
     this.router.navigate(['/admin/add-employee']);
   }
 

--- a/KOService.Presentation/KOService/src/app/admin/home/home.component.ts
+++ b/KOService.Presentation/KOService/src/app/admin/home/home.component.ts
@@ -32,6 +32,7 @@ export class HomeComponent implements OnInit {
    }
 
   ngOnInit() {
+    this.editEmployeeService.employee = null;
     this.getData();
   }
 

--- a/KOService.Presentation/KOService/src/app/admin/home/home.component.ts
+++ b/KOService.Presentation/KOService/src/app/admin/home/home.component.ts
@@ -37,7 +37,6 @@ export class HomeComponent implements OnInit {
   }
 
   ngOnDestroy() {
-    console.log(this.employeeToEdit);
     if (this.editIconClicked) {
       this.editEmployeeService.employee = this.employeeToEdit;
       this.spinnerService.show(); // hide in add-employee - ngOnInit

--- a/KOService.Presentation/KOService/src/app/admin/home/home.component.ts
+++ b/KOService.Presentation/KOService/src/app/admin/home/home.component.ts
@@ -37,7 +37,10 @@ export class HomeComponent implements OnInit {
 
   ngOnDestroy() {
     console.log(this.employeeToEdit);
-    if (this.editIconClicked) this.editEmployeeService.employee = this.employeeToEdit;
+    if (this.editIconClicked) {
+      this.editEmployeeService.employee = this.employeeToEdit;
+      this.spinnerService.show(); // hide in add-employee - ngOnInit
+    }
   }
 
   private getData() {

--- a/KOService.Presentation/KOService/src/app/app.component.ts
+++ b/KOService.Presentation/KOService/src/app/app.component.ts
@@ -1,10 +1,12 @@
 import { Component } from '@angular/core';
 import { Employee } from './shared/models/employee.model';
+import { EditEmployeeService } from './shared/services/editEmployee.service';
 
 @Component({
     selector: 'app-root',
     templateUrl: './app.component.html',
-    styleUrls: ['./app.component.css']
+    styleUrls: ['./app.component.css'],
+    providers: [EditEmployeeService]
 })
 export class AppComponent {
     title = 'KOService';

--- a/KOService.Presentation/KOService/src/app/shared/models/EmployeeWithAccountInfo.model.ts
+++ b/KOService.Presentation/KOService/src/app/shared/models/EmployeeWithAccountInfo.model.ts
@@ -1,0 +1,8 @@
+import { Role } from '../enums/Role';
+export class EmployeeWithAccountInfo {
+    id: string;
+    firstName: string;
+    lastName: string;
+    role: Role;
+    userName: string;
+}

--- a/KOService.Presentation/KOService/src/app/shared/models/employeePassword.model.ts
+++ b/KOService.Presentation/KOService/src/app/shared/models/employeePassword.model.ts
@@ -1,0 +1,4 @@
+export class EmployeePassword {
+    currentPassword : string;
+    newPassword : string;
+}

--- a/KOService.Presentation/KOService/src/app/shared/services/editEmployee.service.ts
+++ b/KOService.Presentation/KOService/src/app/shared/services/editEmployee.service.ts
@@ -1,0 +1,5 @@
+import { Employee } from '../models/employee.model';
+
+export class EditEmployeeService {
+  public employee: Employee;
+}

--- a/KOService.Presentation/KOService/src/app/shared/services/employee.service.ts
+++ b/KOService.Presentation/KOService/src/app/shared/services/employee.service.ts
@@ -10,11 +10,16 @@ import { RegisterEmployee } from '../models/register.model';
 export class EmployeeService {
 
   private baseUrl = 'https://localhost:44340/api/employees';  
+  private userUrl = 'https://localhost:44340/api/user';
 
   constructor(private http: HttpClient) { }
 
   getEmployees(role = null): Observable<Employee[]> {
     return this.http.get<Employee[]>(this.baseUrl, { params: new HttpParams().set('role', role ? role.toString() : null) });
+  }
+
+  getEmployee(id): Observable<Employee> {
+    return this.http.get<Employee>(this.userUrl + '/' + id.toString(), {params: new HttpParams().set('identityId', id ? id.toString() : null)});
   }
 
   terminate(id: string): Observable<any> {

--- a/KOService.Presentation/KOService/src/app/shared/services/employee.service.ts
+++ b/KOService.Presentation/KOService/src/app/shared/services/employee.service.ts
@@ -30,4 +30,8 @@ export class EmployeeService {
   addEmployee(model: RegisterEmployee): Observable<void> {
     return this.http.post<void>('https://localhost:44340/api/register', model);
   }
+  
+  updateEmployee(id: string, model: RegisterEmployee): Observable<void> {
+    return this.http.put<void>(this.baseUrl + '/' + id, model);
+  }
 }

--- a/KOService.Presentation/KOService/src/app/shared/services/employee.service.ts
+++ b/KOService.Presentation/KOService/src/app/shared/services/employee.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { Employee } from '../models/employee.model';
+import { EmployeeWithAccountInfo } from '../models/employeeWithAccountInfo.model';
 import { RegisterEmployee } from '../models/register.model';
 
 @Injectable({
@@ -18,8 +19,8 @@ export class EmployeeService {
     return this.http.get<Employee[]>(this.baseUrl, { params: new HttpParams().set('role', role ? role.toString() : null) });
   }
 
-  getEmployee(id): Observable<Employee> {
-    return this.http.get<Employee>(this.userUrl + '/' + id.toString(), {params: new HttpParams().set('identityId', id ? id.toString() : null)});
+  getEmployee(id: string): Observable<EmployeeWithAccountInfo> {
+    return this.http.get<EmployeeWithAccountInfo>(this.baseUrl + '/' + id.toString(), {params: new HttpParams().set('id', id ? id.toString() : null)});
   }
 
   terminate(id: string): Observable<any> {

--- a/KOService.Presentation/KOService/src/app/shared/services/employee.service.ts
+++ b/KOService.Presentation/KOService/src/app/shared/services/employee.service.ts
@@ -21,7 +21,7 @@ export class EmployeeService {
     return this.http.put<any>(`${this.baseUrl}\\${id}\\terminate`, {});
   }
 
-  addEmployee(model: RegisterEmployee) : Observable<any> {
-    return this.http.post('https://localhost:44340/api/register', model);
+  addEmployee(model: RegisterEmployee): Observable<void> {
+    return this.http.post<void>('https://localhost:44340/api/register', model);
   }
 }

--- a/KOService.Presentation/KOService/src/app/shared/services/employee.service.ts
+++ b/KOService.Presentation/KOService/src/app/shared/services/employee.service.ts
@@ -4,6 +4,7 @@ import { Observable } from 'rxjs';
 import { Employee } from '../models/employee.model';
 import { EmployeeWithAccountInfo } from '../models/employeeWithAccountInfo.model';
 import { RegisterEmployee } from '../models/register.model';
+import { EmployeePassword } from '../models/employeePassword.model';
 
 @Injectable({
   providedIn: 'root'
@@ -33,5 +34,9 @@ export class EmployeeService {
   
   updateEmployee(id: string, model: RegisterEmployee): Observable<void> {
     return this.http.put<void>(this.baseUrl + '/' + id, model);
+  }
+
+  changeEmployeePassword(userName: string, model: EmployeePassword): Observable<void> {
+    return this.http.put<void>(this.userUrl + '/' + userName + '/changePassword', model);
   }
 }

--- a/KOService.WebAPI/Controllers/AuthenticationController.cs
+++ b/KOService.WebAPI/Controllers/AuthenticationController.cs
@@ -61,7 +61,7 @@ namespace KOService.WebAPI.Controllers
                 return BadRequest(commandResult.Exception.InnerException.Message);
             }
 
-            return Ok("Account created");
+            return Ok(new { message = "Account created" });
         }
 
         [HttpPost("login")]

--- a/KOService.WebAPI/Controllers/AuthenticationController.cs
+++ b/KOService.WebAPI/Controllers/AuthenticationController.cs
@@ -102,7 +102,9 @@ namespace KOService.WebAPI.Controllers
                 return NotFound();
             }
 
-            var result = await _userManager.ChangePasswordAsync(identity, dto.CurrentPassword, dto.NewPassword);
+            var token = _userManager.GeneratePasswordResetTokenAsync(identity);
+
+            var result = await _userManager.ResetPasswordAsync(identity, token.Result, dto.NewPassword);
 
             if (!result.Succeeded)
             {

--- a/KOService.WebAPI/Controllers/EmployeesController.cs
+++ b/KOService.WebAPI/Controllers/EmployeesController.cs
@@ -32,8 +32,15 @@ namespace KOService.WebAPI.Controllers
             return Ok(_mediator.Send(new GetEmployeesQuery()).Result);
         }
 
-        [HttpPut("{id}")]
+        [HttpGet("{id}")]
+        public IActionResult GetEmployeeById(string id)
+        {
+            var result = _mediator.Send(new GetEmployeeByIdQuery { Id = id}).Result;
+            int a = 5;
+            return Ok(result);
+        }
 
+        [HttpPut("{id}")]
         public IActionResult UpdateEmployee(string id,[FromBody] UpdateEmployeeCommand command)
         {
             command.Id = id;

--- a/KOService.WebAPI/Infrastructure/AutoMapperConfiguration.cs
+++ b/KOService.WebAPI/Infrastructure/AutoMapperConfiguration.cs
@@ -44,6 +44,9 @@ namespace KOService.WebAPI.Infrastructure
                    .ForMember(dest => dest.ClientPhoneNumber, opt => opt.MapFrom(src => src.Vehicle.Client.ContactDetails.PhoneNumber))
                    .ForMember(dest => dest.ClientName, opt => opt.MapFrom(src => $"{src.Vehicle.Client.FirstName} {src.Vehicle.Client.LastName}"))
                    .ForMember(dest => dest.Status, opt => opt.MapFrom(src => src.GetStatus()));
+
+                cfg.CreateMap<Employee, EmployeeWithAccountInfoDto>()
+                   .ForMember(dest => dest.UserName, opt => opt.MapFrom(src => src.Identity.UserName));
             });
             //Mapper.AssertConfigurationIsValid();
 


### PR DESCRIPTION
Naprawione:
- polskie role na UI, zamiast angielskich, (będę jeszcze poprawiał by używać pipe'a)
- routing po dodaniu pracownika - teraz przechodzi z powrotem do strony /home admina.
- routing przy przycisku edytowania - przechodzi do strony /add-employee, gdzie edytujemy pracownika.
- dodana obsługa spinnera przy dodawaniu/edytowaniu pracownika,
Ta podstrona odpala się już z wypełnionymi polami danymi tego pracownika, którego chcemy edytować.

Dodane:
- Możliwość edycji pracownika z tejże podstrony, można edytować wszystkie pola włącznie z hasłem. (trzeba jeszcze dodać walidację, hasła, myślę że na froncie).

Nie ogarniałem jeszcze tego snack bara, więc to też trzeba będzie dodać.

Ogólnie to jeszcze bałaganu trochę w tym kodzie jeszcze może być, także proszę o sprawdzenie :P